### PR TITLE
Speed up image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM zzxwill/docker-terraform-base:1.0.3-alpha-2
-
-RUN
+FROM oamdev/docker-terraform-base:1.0.3
 
 VOLUME ["/data"]
 
@@ -9,8 +7,8 @@ WORKDIR /data
 ENTRYPOINT ["tail", "-f", "/dev/null"]
 
 ENV TERRAFORM_VERSION=1.0.2
+COPY terraform_${TERRAFORM_VERSION}_linux_amd64.zip /tmp
 RUN cd /tmp && \
-    wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
 
 ARG VCS_REF

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ This is a sub-project of [Terraform Controller](https://github.com/oam-dev/terra
 # Build the image
 
 ```shell
-$ docker build -t zzxwill/docker-terraform:$TAG .
+$ docker build -t oamdev/docker-terraform:$TAG .
 
-$ docker push zzxwill/docker-terraform:$TAG
+$ docker push oamdev/docker-terraform:$TAG
 ```
 
 # oam-dev/docker-terraform
+
+- tag: 1.0.3
+
+Sped up the build of this image.
 
 - tag: 1.0.2
 


### PR DESCRIPTION
Getting Terraform binary, and building the environment for terraform
take about ten minutes to complete. Downloading the binary ahead and
being based on a based image can speed the time for the build