### PR TITLE
Fix: upgrade terraform binary to fix CVE-2021-3538

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-ENV TERRAFORM_VERSION=1.0.2
+ENV TERRAFORM_VERSION=1.1.9
 COPY terraform_${TERRAFORM_VERSION}_linux_amd64.zip /tmp
 RUN cd /tmp && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin


### PR DESCRIPTION
Upgraded Terraform binary version to 1.1.9 to CVE version

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>
