### PR TITLE
Terraform version update to 1.5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-ENV TERRAFORM_VERSION=1.1.9
+ENV TERRAFORM_VERSION=1.5.5
 COPY terraform_${TERRAFORM_VERSION}_linux_amd64.zip /tmp
 RUN cd /tmp && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin


### PR DESCRIPTION
Upgrade to terraform version 1.5.5 to meet the minimum requirements of the latest provider releases